### PR TITLE
feat: 한국투자 증권 종목 리스트 받아오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	//Webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/SMU/StockMate/domain/stock/command/controller/StockInfoUpdateController.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/controller/StockInfoUpdateController.java
@@ -1,0 +1,21 @@
+package SMU.StockMate.domain.stock.command.controller;
+
+import SMU.StockMate.domain.stock.command.service.StockInfoUpdateService;
+import SMU.StockMate.global.apiPayload.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stock")
+public class StockInfoUpdateController {
+    private final StockInfoUpdateService stockInfoUpdateService;
+
+    @PostMapping("/refresh")
+    public CustomResponse<String> refreshStockInfo() {
+        stockInfoUpdateService.update();
+        return CustomResponse.onSuccess("종목 정보를 업데이트 하였습니다.");
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/converter/StockConverter.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/converter/StockConverter.java
@@ -1,0 +1,17 @@
+package SMU.StockMate.domain.stock.command.converter;
+
+import SMU.StockMate.domain.stock.command.dto.StockCodeDto;
+import SMU.StockMate.domain.stock.entity.Stock;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StockConverter {
+    public Stock toStock(StockCodeDto stockCodeDto) {
+        return Stock.builder()
+                .stockCode(stockCodeDto.getShortCode())
+                .standardCode(stockCodeDto.getStandardCode())
+                .koreanName(stockCodeDto.getKoreanName())
+                .basePrice(stockCodeDto.getBasePrice())
+                .build();
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/dto/StockCodeDto.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/dto/StockCodeDto.java
@@ -1,0 +1,27 @@
+package SMU.StockMate.domain.stock.command.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockCodeDto {
+    // 단축 코드
+    private String shortCode;
+
+    // 표준 코드
+    private String standardCode;
+
+    // 한글명
+    private String koreanName;
+
+    // 기준가(전날 종가)
+    private int basePrice;
+
+    public StockCodeDto(String shortCode, String standardCode, String koreanName, int basePrice) {
+        this.shortCode = shortCode;
+        this.standardCode = standardCode;
+        this.koreanName = koreanName;
+        this.basePrice = basePrice;
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/exception/ParsingErrorCode.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/exception/ParsingErrorCode.java
@@ -1,0 +1,12 @@
+package SMU.StockMate.domain.stock.command.exception;
+
+import SMU.StockMate.global.apiPayload.code.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ParsingErrorCode {
+
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/repository/StockRepository.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/repository/StockRepository.java
@@ -1,0 +1,8 @@
+package SMU.StockMate.domain.stock.command.repository;
+
+import SMU.StockMate.domain.stock.entity.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeService.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeService.java
@@ -1,0 +1,14 @@
+package SMU.StockMate.domain.stock.command.service;
+
+import SMU.StockMate.domain.stock.command.dto.StockCodeDto;
+import SMU.StockMate.domain.stock.entity.Stock;
+
+import java.util.List;
+
+public interface StockCodeService {
+
+    // 코스피 종목의 정보를 받아온다
+    public List<StockCodeDto> retrieveKospiMst();
+
+//    public List<StockCodeDto> retrieveKosdacMst();
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeServiceImpl.java
@@ -1,0 +1,116 @@
+package SMU.StockMate.domain.stock.command.service;
+
+import SMU.StockMate.domain.stock.command.dto.StockCodeDto;
+import SMU.StockMate.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Component
+@RequiredArgsConstructor
+public class StockCodeServiceImpl implements StockCodeService {
+
+    private final WebClient webClient;
+
+    // 코스피 코드의 정보가 담겨있는 zip 파일을 가져옴
+    @Override
+    public List<StockCodeDto> retrieveKospiMst() {
+        return webClient.get()
+                .uri("https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip")
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .map(this::parseZipFile)
+                .block();
+    }
+
+//    @Override
+//    public List<StockCodeDto> retrieveKosdacMst() {
+//
+//    }
+
+    /**
+     * zip 파일을 읽어 .mst로 끝나는 파일을 parseMstFile 넘겨서 정보 받아오기
+     * @param zipData
+     * @return StockCodeDto
+     */
+    private List<StockCodeDto> parseZipFile(byte[] zipData) {
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipData))){
+            ZipEntry zipEntry;
+
+            while ((zipEntry = zis.getNextEntry()) != null) {
+                if (zipEntry.getName().endsWith(".mst")) {
+                    return parseMstFile(zis);
+                }
+            }
+        } catch (IOException e) {
+            // 에러 던지기
+        }
+
+        return List.of();
+    }
+
+    /**
+     * mst 파일을 line 별로 읽어서 parseLineToStockCodeDto을 통해 정보 추출하여 list에 저장
+     * @param inputStream
+     * @return
+     */
+    private List<StockCodeDto> parseMstFile(InputStream inputStream) {
+        List<StockCodeDto> codes = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "CP949"))) {
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                StockCodeDto stockCode = parseLineToStockCodeDto(line);
+
+                if (stockCode != null) {
+                    codes.add(stockCode);
+                }
+            }
+        } catch (IOException e) {
+            // 에러 던지기
+        }
+
+        return codes;
+    }
+
+    /**
+     * line 예시
+     * frontPart
+     * - 035720   KR7035720002카카오
+     * backPart: 228자
+     * - ST1002900000000 NNBYYY YYNNNNNNN0NNNNNNNN0000580000000100001NNN00NNN000000020Y0900000020623820000000001002017071000000000044201300000000004425137220012       0 NYY00001863700000105400000192902003000006.7020250331000256367KAONNY
+     */
+    private StockCodeDto parseLineToStockCodeDto(String line) {
+        // 앞부분 추출
+        String frontPart = line.substring(0, line.length() - 228);
+
+        // 단축 코드
+        String shortCode = frontPart.substring(0, 9).trim();
+        //표준 코드
+        String standardCode = frontPart.substring(9, 21).trim();
+        //한글명
+        String koreanName = frontPart.substring(21).trim();
+
+
+        // 뒷부분 228바이트
+        String backPart = line.substring(line.length() - 228);
+        // 기준가(전날 종가)
+        int basePriceStr = Integer.parseInt(backPart.substring(42, 51).trim());
+
+        return StockCodeDto.builder()
+                .shortCode(shortCode)
+                .standardCode(standardCode)
+                .koreanName(koreanName)
+                .basePrice(basePriceStr)
+                .build();
+
+    }
+
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockInfoUpdateService.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockInfoUpdateService.java
@@ -1,0 +1,7 @@
+package SMU.StockMate.domain.stock.command.service;
+
+import org.springframework.stereotype.Service;
+
+public interface StockInfoUpdateService {
+    public void update();
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockInfoUpdateServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockInfoUpdateServiceImpl.java
@@ -1,0 +1,35 @@
+package SMU.StockMate.domain.stock.command.service;
+
+import SMU.StockMate.domain.stock.command.converter.StockConverter;
+import SMU.StockMate.domain.stock.command.dto.StockCodeDto;
+import SMU.StockMate.domain.stock.command.repository.StockRepository;
+import SMU.StockMate.domain.stock.entity.Stock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StockInfoUpdateServiceImpl implements StockInfoUpdateService{
+    private final StockCodeService stockCodeService;
+    private final StockConverter stockConverter;
+    private final StockRepository stockRepository;
+
+    /**
+     * 기존 테이블의 데이터 전체 삭제 후 업데이트
+     */
+    @Override
+    public void update() {
+        List<StockCodeDto> stockCodeDtos = stockCodeService.retrieveKospiMst();
+
+        List<Stock> stocks = stockCodeDtos.stream()
+                .map(stockConverter::toStock)
+                .toList();
+
+        stockRepository.deleteAll();
+        stockRepository.saveAll(stocks);
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/entity/Stock.java
+++ b/src/main/java/SMU/StockMate/domain/stock/entity/Stock.java
@@ -18,4 +18,10 @@ public class Stock extends BaseEntity {
 
     @Column(name = "stock_code")
     private String stockCode;
+
+    private String standardCode;
+
+    private String koreanName;
+
+    private int basePrice;
 }

--- a/src/main/java/SMU/StockMate/global/config/WebClientConfig.java
+++ b/src/main/java/SMU/StockMate/global/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package SMU.StockMate.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}


### PR DESCRIPTION


## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #4 

## 📌 개요
- 한국 투자 증권에서 제공하는 코스피 종목을 받아오는 zip 파일이 있어서 이걸 사용해서 종목 저장

## 🔁 변경 사항
- webclient config 추가
- 한국 투자 증권에서 제공하는 코스피 리스트 받아오기 기능 추가
- 리스트 db에 저장하는 기능 추가(/stock/refresh)
- 코스닥은 아직 추가 X

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.