### PR TITLE
feat: 종목 검색 기능 및 코스닥 정보 가져오기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// Spring Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	testImplementation 'org.springframework.security:spring-security-test'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/SMU/StockMate/domain/stock/command/dto/MarketParsingRule.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/dto/MarketParsingRule.java
@@ -1,0 +1,26 @@
+package SMU.StockMate.domain.stock.command.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum MarketParsingRule {
+    KOSPI(0, 9, 21, 228, 42, 51),
+    KOSDAC(0, 9, 21, 222, 37, 46);
+
+    private final int shortCodeStart;
+    private final int shortCodeEnd;
+    private final int standardCodeEnd;
+    private final int backPartLength;
+    private final int basePriceStart;
+    private final int basePriceEnd;
+
+    MarketParsingRule(int shortCodeStart, int shortCodeEnd, int standardCodeEnd,
+                      int backPartLength, int basePriceStart, int basePriceEnd) {
+        this.shortCodeStart = shortCodeStart;
+        this.shortCodeEnd = shortCodeEnd;
+        this.standardCodeEnd = standardCodeEnd;
+        this.backPartLength = backPartLength;
+        this.basePriceStart = basePriceStart;
+        this.basePriceEnd = basePriceEnd;
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/command/repository/StockCommandRepository.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/repository/StockCommandRepository.java
@@ -3,6 +3,6 @@ package SMU.StockMate.domain.stock.command.repository;
 import SMU.StockMate.domain.stock.entity.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StockRepository extends JpaRepository<Stock, Long> {
+public interface StockCommandRepository extends JpaRepository<Stock, Long> {
 
 }

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeService.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeService.java
@@ -8,7 +8,8 @@ import java.util.List;
 public interface StockCodeService {
 
     // 코스피 종목의 정보를 받아온다
-    public List<StockCodeDto> retrieveKospiMst();
+    List<StockCodeDto> retrieveKospiCode();
 
-//    public List<StockCodeDto> retrieveKosdacMst();
+    // 코스닥 정보를 받아온다
+    List<StockCodeDto> retrieveKosdacCode();
 }

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockCodeServiceImpl.java
@@ -1,5 +1,6 @@
 package SMU.StockMate.domain.stock.command.service;
 
+import SMU.StockMate.domain.stock.command.dto.MarketParsingRule;
 import SMU.StockMate.domain.stock.command.dto.StockCodeDto;
 import SMU.StockMate.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -18,34 +19,60 @@ public class StockCodeServiceImpl implements StockCodeService {
 
     private final WebClient webClient;
 
-    // 코스피 코드의 정보가 담겨있는 zip 파일을 가져옴
+    /**
+     * 코스피 주식 정보를 가져옴
+     * @return
+     */
     @Override
-    public List<StockCodeDto> retrieveKospiMst() {
+    public List<StockCodeDto> retrieveKospiCode() {
+        return retrieveStockMst(
+                "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
+                MarketParsingRule.KOSPI
+        );
+    }
+
+    /**
+     * 코스닥 주식 정보를 가져옴
+     * @return
+     */
+    @Override
+    public List<StockCodeDto> retrieveKosdacCode() {
+        return retrieveStockMst(
+                "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
+                MarketParsingRule.KOSDAC
+        );
+    }
+
+    /**
+     * uri를 찾아가 zip 파일을 가져옴
+     * @param uri
+     * @param rule
+     * @return
+     */
+    private List<StockCodeDto> retrieveStockMst(String uri, MarketParsingRule rule) {
         return webClient.get()
-                .uri("https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip")
+                .uri(uri)
                 .retrieve()
                 .bodyToMono(byte[].class)
-                .map(this::parseZipFile)
+                .map(zipData -> parseZipFile(zipData, rule))
                 .block();
     }
 
-//    @Override
-//    public List<StockCodeDto> retrieveKosdacMst() {
-//
-//    }
+    //TODO: 두개 비동기 적으로 합치기
 
     /**
      * zip 파일을 읽어 .mst로 끝나는 파일을 parseMstFile 넘겨서 정보 받아오기
+     *
      * @param zipData
      * @return StockCodeDto
      */
-    private List<StockCodeDto> parseZipFile(byte[] zipData) {
-        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipData))){
+    private List<StockCodeDto> parseZipFile(byte[] zipData, MarketParsingRule rule) {
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipData))) {
             ZipEntry zipEntry;
 
             while ((zipEntry = zis.getNextEntry()) != null) {
                 if (zipEntry.getName().endsWith(".mst")) {
-                    return parseMstFile(zis);
+                    return parseMstFile(zis, rule);
                 }
             }
         } catch (IOException e) {
@@ -57,17 +84,18 @@ public class StockCodeServiceImpl implements StockCodeService {
 
     /**
      * mst 파일을 line 별로 읽어서 parseLineToStockCodeDto을 통해 정보 추출하여 list에 저장
+     *
      * @param inputStream
      * @return
      */
-    private List<StockCodeDto> parseMstFile(InputStream inputStream) {
+    private List<StockCodeDto> parseMstFile(InputStream inputStream, MarketParsingRule rule) {
         List<StockCodeDto> codes = new ArrayList<>();
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "CP949"))) {
             String line;
 
             while ((line = reader.readLine()) != null) {
-                StockCodeDto stockCode = parseLineToStockCodeDto(line);
+                StockCodeDto stockCode = parseLineToStockCodeDto(line, rule);
 
                 if (stockCode != null) {
                     codes.add(stockCode);
@@ -84,25 +112,25 @@ public class StockCodeServiceImpl implements StockCodeService {
      * line 예시
      * frontPart
      * - 035720   KR7035720002카카오
-     * backPart: 228자
+     * backPart: MarketingRule.backPartLength
      * - ST1002900000000 NNBYYY YYNNNNNNN0NNNNNNNN0000580000000100001NNN00NNN000000020Y0900000020623820000000001002017071000000000044201300000000004425137220012       0 NYY00001863700000105400000192902003000006.7020250331000256367KAONNY
      */
-    private StockCodeDto parseLineToStockCodeDto(String line) {
+    private StockCodeDto parseLineToStockCodeDto(String line, MarketParsingRule rule) {
         // 앞부분 추출
-        String frontPart = line.substring(0, line.length() - 228);
+        String frontPart = line.substring(0, line.length() - rule.getBackPartLength());
 
         // 단축 코드
-        String shortCode = frontPart.substring(0, 9).trim();
+        String shortCode = frontPart.substring(rule.getShortCodeStart(), rule.getShortCodeEnd()).trim();
         //표준 코드
-        String standardCode = frontPart.substring(9, 21).trim();
+        String standardCode = frontPart.substring(rule.getShortCodeEnd(), rule.getStandardCodeEnd()).trim();
         //한글명
-        String koreanName = frontPart.substring(21).trim();
+        String koreanName = frontPart.substring(rule.getStandardCodeEnd()).trim();
 
 
         // 뒷부분 228바이트
-        String backPart = line.substring(line.length() - 228);
+        String backPart = line.substring(line.length() - rule.getBackPartLength());
         // 기준가(전날 종가)
-        int basePriceStr = Integer.parseInt(backPart.substring(42, 51).trim());
+        int basePriceStr = Integer.parseInt(backPart.substring(rule.getBasePriceStart(), rule.getBasePriceEnd()).trim());
 
         return StockCodeDto.builder()
                 .shortCode(shortCode)

--- a/src/main/java/SMU/StockMate/domain/stock/command/service/StockInfoUpdateServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/stock/command/service/StockInfoUpdateServiceImpl.java
@@ -1,35 +1,42 @@
 package SMU.StockMate.domain.stock.command.service;
 
 import SMU.StockMate.domain.stock.command.converter.StockConverter;
-import SMU.StockMate.domain.stock.command.dto.StockCodeDto;
-import SMU.StockMate.domain.stock.command.repository.StockRepository;
+import SMU.StockMate.domain.stock.command.repository.StockCommandRepository;
 import SMU.StockMate.domain.stock.entity.Stock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class StockInfoUpdateServiceImpl implements StockInfoUpdateService{
+public class StockInfoUpdateServiceImpl implements StockInfoUpdateService {
     private final StockCodeService stockCodeService;
     private final StockConverter stockConverter;
-    private final StockRepository stockRepository;
+    private final StockCommandRepository stockRepository;
 
     /**
      * 기존 테이블의 데이터 전체 삭제 후 업데이트
      */
     @Override
     public void update() {
-        List<StockCodeDto> stockCodeDtos = stockCodeService.retrieveKospiMst();
-
-        List<Stock> stocks = stockCodeDtos.stream()
-                .map(stockConverter::toStock)
-                .toList();
+        List<Stock> stocks = combineAllStocks();
 
         stockRepository.deleteAll();
         stockRepository.saveAll(stocks);
     }
+
+    private List<Stock> combineAllStocks() {
+        return Stream.of(
+                        stockCodeService.retrieveKospiCode(),
+                        stockCodeService.retrieveKosdacCode()
+                ).flatMap(Collection::stream)
+                .map(stockConverter::toStock)
+                .toList();
+    }
+
 }

--- a/src/main/java/SMU/StockMate/domain/stock/query/controller/StockInfoSearchController.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/controller/StockInfoSearchController.java
@@ -1,0 +1,29 @@
+package SMU.StockMate.domain.stock.query.controller;
+
+import SMU.StockMate.domain.stock.query.dto.StockInfoResponse;
+import SMU.StockMate.domain.stock.query.service.StockSearchService;
+import SMU.StockMate.global.apiPayload.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stock/search")
+public class StockInfoSearchController {
+
+    private final StockSearchService stockSearchService;
+
+    @GetMapping
+    public CustomResponse<StockInfoResponse> searchStocks(
+            @RequestParam(value = "keyword") String keyword,
+            @RequestParam(value = "cursor") String cursor
+    ) {
+        StockInfoResponse searchedStocks = stockSearchService.search(keyword, cursor);
+        return CustomResponse.onSuccess(searchedStocks);
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/converter/StockQueryConverter.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/converter/StockQueryConverter.java
@@ -1,0 +1,24 @@
+package SMU.StockMate.domain.stock.query.converter;
+
+import SMU.StockMate.domain.stock.entity.Stock;
+import SMU.StockMate.domain.stock.query.dto.StockInfoResponse;
+import SMU.StockMate.domain.stock.query.dto.StocksInfoDto;
+
+import java.util.List;
+
+public class StockQueryConverter {
+    public static StocksInfoDto toStockInfoDto(Stock stock) {
+        return StocksInfoDto.builder()
+                .stockCode(stock.getStockCode())
+                .koreanName(stock.getKoreanName())
+                .basePrice(stock.getBasePrice())
+                .build();
+    }
+
+    public static StockInfoResponse toStockInfoResponse(List<StocksInfoDto> stocksInfoDtos, String nextCursor) {
+        return StockInfoResponse.builder()
+                .stockInfos(stocksInfoDtos)
+                .nextCursor(nextCursor)
+                .build();
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/dto/StockInfoResponse.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/dto/StockInfoResponse.java
@@ -1,0 +1,13 @@
+package SMU.StockMate.domain.stock.query.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StockInfoResponse {
+    private List<StocksInfoDto> stockInfos;
+    private String nextCursor;
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/dto/StocksInfoDto.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/dto/StocksInfoDto.java
@@ -1,0 +1,12 @@
+package SMU.StockMate.domain.stock.query.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StocksInfoDto {
+    private String stockCode;
+    private String koreanName;
+    private int basePrice;
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/repository/StockQueryRepository.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/repository/StockQueryRepository.java
@@ -1,0 +1,19 @@
+package SMU.StockMate.domain.stock.query.repository;
+
+import SMU.StockMate.domain.stock.entity.Stock;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StockQueryRepository extends JpaRepository<Stock, Long> {
+    @Query("SELECT s FROM Stock s " +
+            "WHERE s.stockCode LIKE %:keyword% or s.koreanName LIKE %:keyword% ")
+    List<Stock> findByNameContaining(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT s FROM Stock s " +
+            "WHERE (s.stockCode LIKE %:keyword% OR s.koreanName LIKE %:keyword%) AND s.id > :cursor ")
+    List<Stock> findByNameContainingNextPage(@Param("cursor") Long cursor, @Param("keyword") String keyword, Pageable pageable);
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/service/StockSearchService.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/service/StockSearchService.java
@@ -1,0 +1,9 @@
+package SMU.StockMate.domain.stock.query.service;
+
+import SMU.StockMate.domain.stock.query.dto.StockInfoResponse;
+
+import java.util.List;
+
+public interface StockSearchService {
+    StockInfoResponse search(String keyword, String cursor);
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/service/StockSearchServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/service/StockSearchServiceImpl.java
@@ -1,0 +1,48 @@
+package SMU.StockMate.domain.stock.query.service;
+
+import SMU.StockMate.domain.stock.entity.Stock;
+import SMU.StockMate.domain.stock.query.converter.StockQueryConverter;
+import SMU.StockMate.domain.stock.query.dto.StockInfoResponse;
+import SMU.StockMate.domain.stock.query.dto.StocksInfoDto;
+import SMU.StockMate.domain.stock.query.repository.StockQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class StockSearchServiceImpl implements StockSearchService {
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private final StockQueryRepository stockRepository;
+
+    @Override
+    public StockInfoResponse search(String keyword, String cursor) {
+        Pageable pageable = PageRequest.of(0, DEFAULT_PAGE_SIZE + 1);
+        List<Stock> stocks;
+
+        if (cursor == null || cursor.isEmpty()) {
+            stocks = stockRepository.findByNameContaining(keyword, pageable);
+        } else {
+            long cursorId = Long.parseLong(cursor);
+            stocks = stockRepository.findByNameContainingNextPage(cursorId, keyword, pageable);
+        }
+
+        boolean hasMore = stocks.size() > DEFAULT_PAGE_SIZE;
+        if (hasMore) {
+            stocks.remove(stocks.size() - 1);
+        }
+
+        String nextCursor = hasMore ? stocks.get(stocks.size() - 1).getId().toString() : null;
+
+        List<StocksInfoDto> stocksInfoDtos = stocks.stream()
+                .map(StockQueryConverter::toStockInfoDto)
+                .toList();
+
+        return StockQueryConverter
+                .toStockInfoResponse(stocksInfoDtos, nextCursor);
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #6 

## 📌 개요
- 코스닥 종목 가져와서 저장
- 종목 검색 한국이름 및 종목 코드로 검색 가능
- 더 정확한 종목을 위로 가게 하는 소팅 기능 미구현
- 코스피 및 코스닥 비동기 처리 미구현

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.