### PR TITLE
Feat: 주식  매도 매수 기능 제작

### DIFF
--- a/src/main/java/SMU/StockMate/domain/user/entity/User.java
+++ b/src/main/java/SMU/StockMate/domain/user/entity/User.java
@@ -41,4 +41,16 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();
+
+    // 주식을 매수 한 경우
+    public void decreaseBalance(Long cost) {
+        this.stockValuation += cost;
+        this.cashBalance -= cost;
+    }
+
+    // 주식을 매도한 경우
+    public void increaseBalance(Long cost) {
+        this.stockValuation -= cost;
+        this.cashBalance += cost;
+    }
 }

--- a/src/main/java/SMU/StockMate/domain/userStock/command/controller/UserStockCommandController.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/command/controller/UserStockCommandController.java
@@ -1,0 +1,35 @@
+package SMU.StockMate.domain.userStock.command.controller;
+
+import SMU.StockMate.domain.auth.userDetails.CustomUserDetails;
+import SMU.StockMate.domain.userStock.command.dto.StockTradingRequest;
+import SMU.StockMate.domain.userStock.command.service.UserStockCommandService;
+import SMU.StockMate.global.apiPayload.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stocks")
+public class UserStockCommandController {
+    private final UserStockCommandService userStockCommandService;
+
+    @PostMapping("/buy")
+    public CustomResponse<String> buyStocks(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody StockTradingRequest request) {
+        userStockCommandService.buy(request, customUserDetails.getUsername());
+        return CustomResponse.onSuccess("주식을 매수하였습니다.");
+    }
+
+    @PostMapping("/sell")
+    public CustomResponse<String> sellStocks(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody StockTradingRequest request) {
+        userStockCommandService.sell(request, customUserDetails.getUsername());
+        return CustomResponse.onSuccess("주식을 매도하였습니다.");
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/userStock/command/dto/StockTradingRequest.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/command/dto/StockTradingRequest.java
@@ -1,0 +1,12 @@
+package SMU.StockMate.domain.userStock.command.dto;
+
+import lombok.Getter;
+
+@Getter
+public class StockTradingRequest {
+    private String stockCode;
+
+    private Long stockQuote; // 주식 호가
+
+    private Long quantity;
+}

--- a/src/main/java/SMU/StockMate/domain/userStock/command/exception/UserStockErrorCode.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/command/exception/UserStockErrorCode.java
@@ -1,0 +1,24 @@
+package SMU.StockMate.domain.userStock.command.exception;
+
+
+import SMU.StockMate.global.apiPayload.code.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserStockErrorCode implements BaseErrorCode {
+
+    USER_BALANCE_SHORTAGE(HttpStatus.BAD_REQUEST, "USER_STOCK_001", "사용자의 잔액이 부족합니다."),
+    USER_STOCK_STOCK_QUANTITY_EXCEED(HttpStatus.BAD_REQUEST, "USER_STOCK_002", "보유 수량이 부족합니다."),
+    USER_STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_STOCK_003", "보유 주식을 찾을 수 없습니다."),
+
+    ;
+
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/SMU/StockMate/domain/userStock/command/repository/UserStockCommandRepository.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/command/repository/UserStockCommandRepository.java
@@ -1,0 +1,10 @@
+package SMU.StockMate.domain.userStock.command.repository;
+
+import SMU.StockMate.domain.userStock.entity.UserStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserStockCommandRepository extends JpaRepository<UserStock, Long> {
+    Optional<UserStock> findByUserIdAndStockCode(Long userId, String stockCode);
+}

--- a/src/main/java/SMU/StockMate/domain/userStock/command/service/UserStockCommandService.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/command/service/UserStockCommandService.java
@@ -1,0 +1,19 @@
+package SMU.StockMate.domain.userStock.command.service;
+
+import SMU.StockMate.domain.userStock.command.dto.StockTradingRequest;
+
+public interface UserStockCommandService {
+    /**
+     * 요청하는 호가에 주식을 매수한다.
+     * @param request
+     * @param email
+     */
+    void buy(StockTradingRequest request, String email);
+
+    /**
+     * 요청 호가에 주식을 매도한다.
+     * @param request
+     * @param email
+     */
+    void sell(StockTradingRequest request, String email);
+}

--- a/src/main/java/SMU/StockMate/domain/userStock/command/service/UserStockCommandServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/command/service/UserStockCommandServiceImpl.java
@@ -1,0 +1,86 @@
+package SMU.StockMate.domain.userStock.command.service;
+
+import SMU.StockMate.domain.auth.code.ErrorCode;
+import SMU.StockMate.domain.user.entity.User;
+import SMU.StockMate.domain.user.repository.UserRepository;
+import SMU.StockMate.domain.userStock.command.dto.StockTradingRequest;
+import SMU.StockMate.domain.userStock.command.exception.UserStockErrorCode;
+import SMU.StockMate.domain.userStock.command.repository.UserStockCommandRepository;
+import SMU.StockMate.domain.userStock.entity.UserStock;
+import SMU.StockMate.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class UserStockCommandServiceImpl implements UserStockCommandService {
+
+    private final UserRepository userRepository;
+    private final UserStockCommandRepository userStockCommandRepository;
+
+    @Override
+    public void buy(StockTradingRequest request, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Long totalCost = request.getQuantity() * request.getStockQuote();
+        validateUserCashBalance(user, totalCost);
+
+        // 매수하고자 하는 주식을 가지고 있으면 해당 주식을 아니면 새로운 주식 반환
+        UserStock userStock = userStockCommandRepository
+                .findByUserIdAndStockCode(user.getId(), request.getStockCode())
+                .orElseGet(() -> {
+                    UserStock newStock = createNewUserStock(user, request);
+                    return userStockCommandRepository.save(newStock);
+                });
+
+        userStock.addStock(request.getQuantity(), totalCost);
+        user.decreaseBalance(totalCost);
+    }
+
+    @Override
+    public void sell(StockTradingRequest request, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Long totalCost = request.getQuantity() * request.getStockQuote();
+
+
+        UserStock userStock = userStockCommandRepository
+                .findByUserIdAndStockCode(user.getId(), request.getStockCode())
+                .orElseThrow(() -> new CustomException(UserStockErrorCode.USER_STOCK_NOT_FOUND));
+
+
+        // 보유 수량 보다 매도 수량이 많으면 에러
+        validateUserStockQuantity(userStock, request.getQuantity());
+
+        userStock.reduceStock(request.getQuantity(), totalCost);
+        user.increaseBalance(totalCost);
+    }
+
+    private UserStock createNewUserStock(User user, StockTradingRequest request) {
+        return UserStock.builder()
+                .user(user)
+                .stockCode(request.getStockCode())
+                .quantity(0L)
+                .totalAmount(0L)
+                .build();
+    }
+
+    private void validateUserStockQuantity(UserStock userStock, Long quantity) {
+        if (userStock.getQuantity() < quantity) {
+            throw new CustomException(UserStockErrorCode.USER_STOCK_STOCK_QUANTITY_EXCEED);
+        }
+    }
+
+    private void validateUserCashBalance(User user, Long totalCost) {
+        if (user.getCashBalance() < totalCost) {
+            throw new CustomException(UserStockErrorCode.USER_BALANCE_SHORTAGE);
+        }
+    }
+}

--- a/src/main/java/SMU/StockMate/domain/userStock/entity/UserStock.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/entity/UserStock.java
@@ -26,7 +26,7 @@ public class UserStock extends BaseEntity {
     @Column(name = "avg_price")
     private Long avgPrice; // 평균 매수 금액
 
-    private Long returns; // 수익률
+//    private Long returns; // 수익률
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/SMU/StockMate/domain/userStock/entity/UserStock.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/entity/UserStock.java
@@ -21,6 +21,8 @@ public class UserStock extends BaseEntity {
 
     private Long quantity; // 보유 수량
 
+    private Long totalAmount; // 총액
+
     @Column(name = "avg_price")
     private Long avgPrice; // 평균 매수 금액
 
@@ -29,4 +31,24 @@ public class UserStock extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void addStock(Long quantity, Long totalAmount) {
+        this.quantity += quantity;
+        this.totalAmount += totalAmount;
+        updateAvgPrice();
+    }
+
+    public void reduceStock(Long quantity, Long totalAmount) {
+        this.quantity -= quantity;
+        this.totalAmount -= totalAmount;
+        updateAvgPrice();
+    }
+
+    private void updateAvgPrice() {
+        if (this.quantity > 0) {
+            this.avgPrice = this.totalAmount / this.quantity;
+        } else {
+            this.avgPrice = 0L;
+        }
+    }
 }

--- a/src/test/java/SMU/StockMate/domain/userStock/command/service/UserStockCommandServiceImplTest.java
+++ b/src/test/java/SMU/StockMate/domain/userStock/command/service/UserStockCommandServiceImplTest.java
@@ -1,0 +1,178 @@
+package SMU.StockMate.domain.userStock.command.service;
+
+import SMU.StockMate.domain.user.entity.User;
+import SMU.StockMate.domain.user.repository.UserRepository;
+import SMU.StockMate.domain.userStock.command.dto.StockTradingRequest;
+import SMU.StockMate.domain.userStock.command.exception.UserStockErrorCode;
+import SMU.StockMate.domain.userStock.command.repository.UserStockCommandRepository;
+import SMU.StockMate.domain.userStock.entity.UserStock;
+import SMU.StockMate.global.apiPayload.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserStockCommandServiceImplTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    UserStockCommandRepository userStockCommandRepository;
+
+    @InjectMocks
+    UserStockCommandServiceImpl userStockCommandService;
+
+    private User user;
+    private StockTradingRequest tradingRequest;
+    private UserStock existingUserStock;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("test")
+                .cashBalance(100000L)
+                .stockValuation(100000L)
+                .build();
+
+        tradingRequest = createStockTradingRequest("카카오", 1000L, 10L);
+
+        existingUserStock = UserStock.builder()
+                .id(1L)
+                .user(user)
+                .stockCode("카카오")
+                .quantity(20L)
+                .totalAmount(20000L)
+                .avgPrice(1000L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("매수 실패 - 잔액 부족")
+    void buy_stock_not_enough_balance() throws Exception{
+        // given
+        User notEnoughBalanceUser = User.builder()
+                .id(2L)
+                .email("poor")
+                .cashBalance(5000L)
+                .totalAsset(5000L)
+                .build();
+        when(userRepository.findByEmail("poor")).thenReturn(Optional.ofNullable(notEnoughBalanceUser));
+
+        // when, then
+        assertThatThrownBy(() -> userStockCommandService.buy(tradingRequest, "poor"))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(UserStockErrorCode.USER_BALANCE_SHORTAGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("매수 성공 - 새로운 주식")
+    void buy_new_stock_with_enough_balance() throws Exception{
+        // given
+        when(userRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        when(userStockCommandRepository.findByUserIdAndStockCode(1L, "카카오"))
+                .thenReturn(Optional.empty());
+        // 실제 서비스 코드의 값 반환
+        when(userStockCommandRepository.save(any(UserStock.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        userStockCommandService.buy(tradingRequest, "test");
+
+        // then
+        verify(userStockCommandRepository).save(any(UserStock.class));
+
+        assertThat(user.getCashBalance()).isEqualTo(90000L);
+        assertThat(user.getStockValuation()).isEqualTo(110000L);
+    }
+
+    @Test
+    @DisplayName("매수 성공 - 보유 주식")
+    void buy_exists_stock_with_enough_balance() throws Exception{
+        // given
+        when(userRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        when(userStockCommandRepository.findByUserIdAndStockCode(1L, "카카오"))
+                .thenReturn(Optional.ofNullable(existingUserStock));
+
+        // when
+        userStockCommandService.buy(tradingRequest, "test");
+
+        // then
+        assertThat(user.getCashBalance()).isEqualTo(90000L);
+        assertThat(user.getStockValuation()).isEqualTo(110000L);
+        assertThat(existingUserStock.getQuantity()).isEqualTo(30L);
+        assertThat(existingUserStock.getTotalAmount()).isEqualTo(30000L);
+    }
+
+    @Test
+    @DisplayName("매도 성공 - 일부 매도")
+    void sell_success() throws Exception{
+        // given
+        when(userRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        when(userStockCommandRepository.findByUserIdAndStockCode(1L, "카카오"))
+                .thenReturn(Optional.ofNullable(existingUserStock));
+
+        // when
+        userStockCommandService.sell(tradingRequest, "test");
+
+        // then
+        assertThat(existingUserStock.getQuantity()).isEqualTo(10L);
+        assertThat(existingUserStock.getTotalAmount()).isEqualTo(10000L);
+    }
+
+    @Test
+    @DisplayName("매도 실패 - 보유하지 않은 주식")
+    void sell_fail_not_found() throws Exception{
+        // given
+        when(userRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+
+        // when, then
+        assertThatThrownBy(() -> userStockCommandService.sell(tradingRequest, "test"))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(UserStockErrorCode.USER_STOCK_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("매도 실패 - 수량 부족")
+    void sell_fail_not_enough_quantity() throws Exception{
+        // given
+        when(userRepository.findByEmail("test")).thenReturn(Optional.ofNullable(user));
+        when(userStockCommandRepository.findByUserIdAndStockCode(1L, "카카오"))
+                .thenReturn(Optional.ofNullable(existingUserStock));
+
+        StockTradingRequest sellRequest = createStockTradingRequest("카카오", 5L, 25L);
+
+        // when, then
+        assertThatThrownBy(() -> userStockCommandService.sell(sellRequest, "test"))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(UserStockErrorCode.USER_STOCK_STOCK_QUANTITY_EXCEED.getMessage());
+
+    }
+
+    private StockTradingRequest createStockTradingRequest(String stockCode, Long stockQuote, Long quantity) {
+        return new StockTradingRequest() {
+            public String getStockCode() { return stockCode; }
+            public Long getStockQuote() { return stockQuote; }
+            public Long getQuantity() { return quantity; }
+        };
+    }
+
+    private UserStock createNewUserStock(User user, StockTradingRequest request) {
+        return UserStock.builder()
+                .user(user)
+                .stockCode(request.getStockCode())
+                .quantity(0L)
+                .totalAmount(0L)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #21 

## 📌 개요
- 주식 매수 매도 기능 제작

## 🔁 변경 사항
 - 주식 매수 시 UserStock의 quantity, totalAmount 를 변경
 - User의 cashBalance(예수금), stockValuation(주식 평가액) 변경


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 현재 totalAmount, stockValuation을 주식 매수 시점의 총액으로 변경하고 있는데 이걸 실시간 값으로 변경해야함
 - 평균 매수 금액을 db 에 저장 vs 요청이 계산하여 반환에 대해 뭐가 더 좋을까요?
 - returns(수익률) 은 실시간으로 변동 되기 때문에 이 속성 삭제하는 것이 어떨까요?

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.