### PR TITLE
Feat: 현재가 조회 추가 및 불필요한 로그 삭제

### DIFF
--- a/src/main/java/SMU/StockMate/domain/stock/query/controller/StockPriceController.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/controller/StockPriceController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v0/stocks")
+@RequestMapping("/stocks")
 public class StockPriceController {
 
     private final StockPriceService stockPriceService;

--- a/src/main/java/SMU/StockMate/domain/stock/query/controller/StockPriceController.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/controller/StockPriceController.java
@@ -1,0 +1,28 @@
+package SMU.StockMate.domain.stock.query.controller;
+
+import SMU.StockMate.domain.stock.query.dto.StockPriceResponseDTO;
+import SMU.StockMate.domain.stock.query.service.StockPriceService;
+import SMU.StockMate.global.apiPayload.CustomResponse;
+import SMU.StockMate.global.apiPayload.code.success.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v0/stocks")
+public class StockPriceController {
+
+    private final StockPriceService stockPriceService;
+
+    @GetMapping("/{symbol}/price")
+    public CustomResponse<StockPriceResponseDTO> getPrice(@PathVariable String symbol) {
+        var result = stockPriceService.getPrice(symbol.trim());
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, result);
+
+    }
+
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/dto/StockPriceResponseDTO.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/dto/StockPriceResponseDTO.java
@@ -1,0 +1,24 @@
+package SMU.StockMate.domain.stock.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockPriceResponseDTO {
+    private String symbol;
+    private String name;
+    private long price;
+    private long change;
+    private double changePercent;
+    private long volume;
+    private OffsetDateTime timestamp;
+
+
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/service/StockPriceService.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/service/StockPriceService.java
@@ -1,0 +1,7 @@
+package SMU.StockMate.domain.stock.query.service;
+
+import SMU.StockMate.domain.stock.query.dto.StockPriceResponseDTO;
+
+public interface StockPriceService {
+    StockPriceResponseDTO getPrice(String stockCode);
+}

--- a/src/main/java/SMU/StockMate/domain/stock/query/service/StockPriceServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/stock/query/service/StockPriceServiceImpl.java
@@ -1,0 +1,83 @@
+package SMU.StockMate.domain.stock.query.service;
+
+import SMU.StockMate.domain.stock.entity.Stock;
+import SMU.StockMate.domain.stock.query.dto.StockPriceResponseDTO;
+import SMU.StockMate.domain.stock.query.repository.StockQueryRepository;
+import SMU.StockMate.global.kis.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StockPriceServiceImpl implements StockPriceService{
+    @Value("${kis.api.app-key}")    private String appKey;
+    @Value("${kis.api.app-secret}") private String appSecret;
+
+    private static final String TR_ID = "FHKST01010100";
+    private static final String BASE_URL = "https://openapivts.koreainvestment.com:29443";
+    private static final String PATH = "/uapi/domestic-stock/v1/quotations/inquire-price";
+    private static final DateTimeFormatter KIS_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final StockQueryRepository stockQueryRepository;
+    private final TokenService tokenService;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    @Override
+    public StockPriceResponseDTO getPrice(String stockCode) {
+
+        final Stock stock = stockQueryRepository.findByStockCode(stockCode)
+                .orElseThrow(() -> new IllegalArgumentException("알 수 없는 종목 코드: " + stockCode));
+
+        var token = tokenService.getAccessToken();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token.accessToken());
+        headers.set("appkey", appKey);
+        headers.set("appsecret", appSecret);
+        headers.set("tr_id", TR_ID);
+        headers.set("custtype", "P");
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        URI uri = UriComponentsBuilder.fromHttpUrl(BASE_URL + PATH)
+                .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                .queryParam("FID_INPUT_ISCD", stockCode)
+                .build(true)
+                .toUri();
+
+        ResponseEntity<Map> res = restTemplate.exchange(uri, HttpMethod.GET, new HttpEntity<>(headers), Map.class);
+        Map body = Optional.ofNullable(res.getBody())
+                .orElseThrow(() -> new IllegalStateException("현재가 응답이 없음"));
+
+        Map<String, Object> output = (Map<String, Object>) body.get("output");
+        long current = Long.parseLong(output.get("stck_prpr").toString());
+        long change = Long.parseLong(output.get("prdy_vrss").toString());
+        double percent = Double.parseDouble(output.get("prdy_ctrt").toString().trim());
+        long volume = Long.parseLong(output.get("acml_vol").toString());
+
+        return StockPriceResponseDTO.builder()
+                .symbol(stock.getStockCode())
+                .name(stock.getKoreanName())
+                .price(current)
+                .change(change)
+                .changePercent(percent)
+                .volume(volume)
+                .timestamp(OffsetDateTime.now(ZoneId.of("Asia/Seoul"))) // 서울 기준 현재가 조회 시점 표시
+                .build();
+    }
+
+
+}

--- a/src/main/java/SMU/StockMate/global/kis/KisAuthClient.java
+++ b/src/main/java/SMU/StockMate/global/kis/KisAuthClient.java
@@ -47,7 +47,6 @@ public class KisAuthClient {
             objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
 
             TokenResponseDto token = objectMapper.readValue(response.getBody(), TokenResponseDto.class);
-            log.info("발급된 토큰: {}", token.accessToken());
             return token;
 
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #28

## 📌 개요
- 한국투자증권 API를 이용하여 현재가(시세)조회를 구현합니다.
- stock 테이블에 조회하고자 하는 종목 데이터가 있어야 합니다.

## 🔁 변경 사항
- 테스트 과정에서 토큰을 log에 찍는 코드가 발견되어 삭제했습니다.

## 📸 스크린샷
<img width="1389" height="1038" alt="image" src="https://github.com/user-attachments/assets/e8dc6dde-517b-489c-a84b-c3e3a3da200f" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.