### PR TITLE
feat: 전체 사용자 기준 기간별 수익률 기능 추가

### DIFF
--- a/src/main/java/SMU/StockMate/domain/leaderBoard/controller/LeaderBoardController.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/controller/LeaderBoardController.java
@@ -1,4 +1,48 @@
 package SMU.StockMate.domain.leaderBoard.controller;
 
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardDTO;
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardUserDTO;
+import SMU.StockMate.domain.leaderBoard.service.LeaderBoardBatchService;
+import SMU.StockMate.domain.leaderBoard.service.query.LeaderBoardQueryService;
+import SMU.StockMate.global.apiPayload.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@RestController
+@RequestMapping("/leaderboard")
+@RequiredArgsConstructor
 public class LeaderBoardController {
+
+    private final LeaderBoardQueryService leaderBoardQueryService;
+    private final LeaderBoardBatchService batchService;
+
+    // 날짜별 TOP100 (date=YYYY-MM-DD, 값이 없는 경우 -> 디폴트 값은 현재 날짜 기준으로 어제 값)
+    @GetMapping("/top100")
+    public CustomResponse<List<LeaderBoardDTO>> getTop100ByDate(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        List<LeaderBoardDTO> ranking =
+                leaderBoardQueryService.getTop100ByDate(date != null ? date : LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1));
+
+        return CustomResponse.onSuccess(ranking);
+    }
+
+    @GetMapping("/top100/{userId}")
+    public CustomResponse<LeaderBoardUserDTO> getUserInLeaderBoard(@PathVariable Long userId) {
+        LeaderBoardUserDTO dto = leaderBoardQueryService.getUserInLeaderBoard(userId);
+
+        return CustomResponse.onSuccess(dto);
+    }
+
+    // 자동 순위 생성에서 문제가 생긴 경우 - 수동으로 재생성
+    @PostMapping("/rebuild")
+    public CustomResponse<String> rebuild(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        int count = batchService.rebuildTopByReturn(date);
+
+        return CustomResponse.onSuccess("Rebuilt " + count + " rows for date " + date);
+    }
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/controller/LeaderBoardController.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/controller/LeaderBoardController.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.controller;
+
+public class LeaderBoardController {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/controller/UserDailyStatsAdminController.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/controller/UserDailyStatsAdminController.java
@@ -1,4 +1,37 @@
 package SMU.StockMate.domain.leaderBoard.controller;
 
+import SMU.StockMate.domain.leaderBoard.service.UserDailyStatsBatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/admin/stats")
+@RequiredArgsConstructor
 public class UserDailyStatsAdminController {
+
+    private final UserDailyStatsBatchService statsBatchService;
+
+    // 단일 일자 재집계: /admin/stats/rebuild?date=2025-08-25
+    @PostMapping("/rebuild")
+    public String rebuild(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        int rows = statsBatchService.buildFor(date);
+        return "user_daily_stats rebuilt for " + date + " : " + rows + " rows";
+    }
+
+    // 구간 백필: /admin/stats/rebuild-range?from=2025-08-01&to=2025-08-25
+    @PostMapping("/rebuild-range")
+    public String rebuildRange(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        int rows = statsBatchService.buildRange(from, to);
+        return "user_daily_stats rebuilt from " + from + " to " + to + " : " + rows + " rows total";
+    }
 }
+

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/controller/UserDailyStatsAdminController.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/controller/UserDailyStatsAdminController.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.controller;
+
+public class UserDailyStatsAdminController {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardDTO.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardDTO.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 public record LeaderBoardDTO (
         Long userId,
+        Integer rank,
         String nickname,
         BigDecimal totalReturns,
         Long totalAsset

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardDTO.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardDTO.java
@@ -1,0 +1,10 @@
+package SMU.StockMate.domain.leaderBoard.dto;
+
+import java.math.BigDecimal;
+
+public record LeaderBoardDTO (
+        Long userId,
+        String nickname,
+        BigDecimal totalReturns,
+        Long totalAsset
+) {}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardUserDTO.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardUserDTO.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.dto;
+
+public record LeaderBoardUserDTO() {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardUserDTO.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/dto/LeaderBoardUserDTO.java
@@ -1,4 +1,16 @@
 package SMU.StockMate.domain.leaderBoard.dto;
 
-public record LeaderBoardUserDTO() {
-}
+import SMU.StockMate.domain.userStock.dto.UserStockResponseDTO;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record LeaderBoardUserDTO(
+    String nickname,
+    Long stockValuation, // 주식 평가 금액
+    Long stockTotalBuyAmount, // 주식 매입 금액
+    BigDecimal totalReturns, // 수익률
+    List<UserStockResponseDTO.toPortfolioDTO> userStockList
+) {}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/entity/LeaderBoard.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/entity/LeaderBoard.java
@@ -7,7 +7,18 @@ import lombok.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-@Table(name = "leader_board")
+@Table(
+        name = "leader_board",
+        uniqueConstraints = {
+                // 같은 날짜에 동일한 순위, 동일한 유저가 없도록 제약 조건
+                @UniqueConstraint(name = "unique_leaderboard_date_rank", columnNames = {"date","rank_no"}),
+                @UniqueConstraint(name = "uq_leaderboard_date_user", columnNames = {"date", "user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_leaderboard_date", columnList = "date"),
+        }
+
+)
 @Entity
 @Getter
 @Builder
@@ -19,12 +30,22 @@ public class LeaderBoard extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private LocalDate date; // 순위 날짜
-    private Integer ranking;
 
+    @Column(name = "rank_no",nullable = false)
+    private Integer rank; // 1~100등 까지
+
+    @Column(name = "user_id", nullable = false)
     private Long userId;
-    private String username;
+
+    @Column(nullable = false, length = 30)
+    private String nickname;
+
+    @Column(name = "total_asset", nullable = false)
     private Long totalAsset;
+
+    @Column(name = "total_returns", nullable = false, precision = 18, scale = 8) // 전체 자리 = 18, 소수점 자리 = 8
     private BigDecimal totalReturns;
 
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/entity/LeaderBoard.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/entity/LeaderBoard.java
@@ -1,0 +1,30 @@
+package SMU.StockMate.domain.leaderBoard.entity;
+
+import SMU.StockMate.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Table(name = "leader_board")
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LeaderBoard extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate date; // 순위 날짜
+    private Integer ranking;
+
+    private Long userId;
+    private String username;
+    private Long totalAsset;
+    private BigDecimal totalReturns;
+
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/entity/LeaderBoardCandidate.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/entity/LeaderBoardCandidate.java
@@ -1,0 +1,10 @@
+package SMU.StockMate.domain.leaderBoard.entity;
+
+import java.math.BigDecimal;
+
+public interface LeaderBoardCandidate {
+    Long getUserId();
+    String getNickname();
+    BigDecimal getTotalReturns();
+    Long getTotalAsset();
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/repository/LeaderBoardRepository.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/repository/LeaderBoardRepository.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.repository;
+
+public interface LeaderBoardRepository {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/repository/LeaderBoardRepository.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/repository/LeaderBoardRepository.java
@@ -1,4 +1,41 @@
 package SMU.StockMate.domain.leaderBoard.repository;
 
-public interface LeaderBoardRepository {
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardDTO;
+import SMU.StockMate.domain.leaderBoard.entity.LeaderBoard;
+import SMU.StockMate.domain.leaderBoard.entity.LeaderBoardCandidate;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface LeaderBoardRepository extends JpaRepository<LeaderBoard, Long> {
+    // JPQL을 사용한 특정 날짜 상위 100
+    @Query("""
+        SELECT new SMU.StockMate.domain.leaderBoard.dto.LeaderBoardDTO(
+           ld.userId, ld.rank, ld.nickname, ld.totalReturns, ld.totalAsset
+      )
+      FROM LeaderBoard ld
+      WHERE ld.date = :date
+      ORDER BY ld.rank ASC
+      """)
+    List<LeaderBoardDTO> findTop100ByDate(@Param("date") LocalDate date, Pageable pageable);
+
+    @Query(value = """
+        SELECT 
+            uds.user_id      AS userId,
+            u.nickname       AS nickname,
+            uds.total_returns AS totalReturns,
+            uds.total_asset   AS totalAsset
+        FROM user_daily_stats uds
+        JOIN users u ON u.user_id = uds.user_id
+        WHERE uds.date = :date
+    """, nativeQuery = true)
+    List<LeaderBoardCandidate> findCandidates(@Param("date") LocalDate date);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    long deleteByDate(LocalDate date);
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/LeaderBoardScheduler.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/LeaderBoardScheduler.java
@@ -1,4 +1,25 @@
 package SMU.StockMate.domain.leaderBoard.scheduler;
 
+import SMU.StockMate.domain.leaderBoard.service.LeaderBoardBatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
 public class LeaderBoardScheduler {
+
+    private final LeaderBoardBatchService batchService;
+
+    // 매일 21:00 KST
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    public void buildDaily() {
+        LocalDate target = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        int saved = batchService.rebuildTopByReturn(target);
+
+        System.out.println("[LeaderBoardScheduler] " + target + " 저장: " + saved + "건");
+    }
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/LeaderBoardScheduler.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/LeaderBoardScheduler.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.scheduler;
+
+public class LeaderBoardScheduler {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/UserDailyStatsScheduler.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/UserDailyStatsScheduler.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.scheduler;
+
+public class UserDailyStatsScheduler {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/UserDailyStatsScheduler.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/scheduler/UserDailyStatsScheduler.java
@@ -1,4 +1,24 @@
 package SMU.StockMate.domain.leaderBoard.scheduler;
 
+import SMU.StockMate.domain.leaderBoard.service.UserDailyStatsBatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
 public class UserDailyStatsScheduler {
+
+    private final UserDailyStatsBatchService statsBatchService;
+
+    // 매일 20:55 KST — 리더보드(21:00) 전에 집계 생성
+    @Scheduled(cron = "0 55 20 * * *", zone = "Asia/Seoul")
+    public void buildDailyStats() {
+        LocalDate target = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        int rows = statsBatchService.buildFor(target);
+        System.out.println("[UserDailyStatsScheduler] " + target + " 집계: " + rows + "건");
+    }
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/LeaderBoardBatchService.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/LeaderBoardBatchService.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.service;
+
+public class LeaderBoardBatchService {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/LeaderBoardBatchService.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/LeaderBoardBatchService.java
@@ -1,4 +1,61 @@
 package SMU.StockMate.domain.leaderBoard.service;
 
+import SMU.StockMate.domain.leaderBoard.entity.LeaderBoard;
+import SMU.StockMate.domain.leaderBoard.entity.LeaderBoardCandidate;
+import SMU.StockMate.domain.leaderBoard.repository.LeaderBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class LeaderBoardBatchService {
+
+    private final LeaderBoardRepository repo;
+
+    @Transactional
+    public int rebuildTopByReturn(LocalDate date) {
+        // 1) 해당 날짜 기존 랭킹 제거
+        repo.deleteByDate(date);
+
+        // 2) 후보 조회 (user_daily_stats)
+        var all = repo.findCandidates(date);
+        if (all.isEmpty()) return 0;
+
+        // 3) 수익률 DESC, 자산 DESC, userId ASC
+        var top = all.stream()
+                .sorted(Comparator
+                        .comparing(LeaderBoardCandidate::getTotalReturns,
+                                Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(LeaderBoardCandidate::getTotalAsset,
+                                Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(LeaderBoardCandidate::getUserId,
+                                Comparator.nullsLast(Comparator.naturalOrder())))
+                .limit(100)
+                .toList();
+
+        // 4) 1..N등 부여 후 저장
+        List<LeaderBoard> rows = new ArrayList<>(top.size());
+
+        for (int i = 0; i < top.size(); i++) {
+            var c = top.get(i);
+            rows.add(LeaderBoard.builder()
+                    .date(date)
+                    .rank(i + 1)
+                    .userId(c.getUserId())
+                    .nickname(c.getNickname())
+                    .totalAsset(c.getTotalAsset())
+                    .totalReturns(c.getTotalReturns())
+                    .build());
+        }
+
+        repo.saveAll(rows);
+        return rows.size();
+    }
 }
+

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/UserDailyStatsBatchService.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/UserDailyStatsBatchService.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.service;
+
+public class UserDailyStatsBatchService {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/UserDailyStatsBatchService.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/UserDailyStatsBatchService.java
@@ -1,4 +1,55 @@
 package SMU.StockMate.domain.leaderBoard.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
 public class UserDailyStatsBatchService {
+
+    private final JdbcTemplate jdbc;
+
+    @Transactional
+    public int buildFor(LocalDate date) {
+        jdbc.update("DELETE FROM `user_daily_stats` WHERE `date` = ?",
+                ps -> ps.setDate(1, java.sql.Date.valueOf(date)));
+
+        String sql = """
+        INSERT INTO `user_daily_stats` (`date`, `user_id`, `total_asset`, `total_returns`)
+        SELECT
+            ? AS stat_date,
+            u.`user_id`,
+            (COALESCE(MAX(u.`cash_balance`), 0)
+               + COALESCE(SUM(us.`quantity` * s.`base_price`), 0))                  AS total_asset,
+            CASE
+                WHEN COALESCE(SUM(us.`total_amount`), 0) > 0 THEN
+                    (
+                      (COALESCE(MAX(u.`cash_balance`), 0) + COALESCE(SUM(us.`quantity` * s.`base_price`), 0))
+                      - COALESCE(SUM(us.`total_amount`), 0)
+                    ) / COALESCE(SUM(us.`total_amount`), 0)
+                ELSE 0
+            END
+                AS total_returns
+        FROM `users` u
+        LEFT JOIN `user_stock` us ON us.`user_id` = u.`user_id`
+        LEFT JOIN `stock` s       ON s.`id` = us.`stock_id`
+        GROUP BY u.`user_id`;
+        """;
+
+        return jdbc.update(sql, ps -> ps.setDate(1, java.sql.Date.valueOf(date)));
+    }
+
+    @Transactional
+    public int buildRange(LocalDate from, LocalDate toInclusive) {
+        int total = 0;
+
+        for (LocalDate d = from; !d.isAfter(toInclusive); d = d.plusDays(1)) {
+            total += buildFor(d);
+        }
+        return total;
+    }
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryService.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryService.java
@@ -1,4 +1,14 @@
 package SMU.StockMate.domain.leaderBoard.service.query;
 
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardDTO;
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardUserDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
 public interface LeaderBoardQueryService {
+
+    List<LeaderBoardDTO> getTop100ByDate(LocalDate date);
+
+    LeaderBoardUserDTO getUserInLeaderBoard(Long userId);
 }

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryService.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryService.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.service.query;
+
+public interface LeaderBoardQueryService {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryServiceImpl.java
@@ -1,0 +1,4 @@
+package SMU.StockMate.domain.leaderBoard.service.query;
+
+public class LeaderBoardQueryServiceImpl {
+}

--- a/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/leaderBoard/service/query/LeaderBoardQueryServiceImpl.java
@@ -1,4 +1,86 @@
 package SMU.StockMate.domain.leaderBoard.service.query;
 
-public class LeaderBoardQueryServiceImpl {
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardDTO;
+import SMU.StockMate.domain.leaderBoard.dto.LeaderBoardUserDTO;
+import SMU.StockMate.domain.leaderBoard.repository.LeaderBoardRepository;
+import SMU.StockMate.domain.user.code.UserErrorCode;
+import SMU.StockMate.domain.user.entity.User;
+import SMU.StockMate.domain.user.repository.UserRepository;
+import SMU.StockMate.domain.userStock.dto.UserStockResponseDTO;
+import SMU.StockMate.domain.userStock.entity.UserStock;
+import SMU.StockMate.domain.userStock.repository.UserStockRepository;
+import SMU.StockMate.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LeaderBoardQueryServiceImpl implements LeaderBoardQueryService {
+
+    private final LeaderBoardRepository leaderBoardRepository;
+    private final UserRepository userRepository;
+    private final UserStockRepository userStockRepository;
+
+    @Override
+    public List<LeaderBoardDTO> getTop100ByDate(LocalDate date) {
+        return leaderBoardRepository.findTop100ByDate(date, PageRequest.of(0, 100));
+    }
+
+    @Override
+    public LeaderBoardUserDTO getUserInLeaderBoard(Long userId) {
+        User user = userRepository.findById(userId).
+                orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        // N+1 문제 -> Fetch join 사용해보고 차이점 찾아볼 것
+        List<UserStockResponseDTO.toPortfolioDTO> userStocks = userStockRepository.findByUserId(user.getId()).stream()
+                .map(userStock -> UserStockResponseDTO.toPortfolioDTO
+                        .builder()
+                        .koreanName(userStock.getStock().getKoreanName())
+                        .basePrice(userStock.getStock().getBasePrice())
+                        .totalAmount(userStock.getTotalAmount())
+                        .avgPrice(userStock.getAvgPrice())
+                        .quantity(userStock.getQuantity())
+                        .returns(calculateReturns(userStock))
+                        .build())
+                .toList();
+
+        return LeaderBoardUserDTO.builder()
+                .nickname(user.getNickname())
+                .stockValuation(user.getStockValuation())
+                .stockTotalBuyAmount(user.getStockTotalBuyAmount())
+                .totalReturns(user.getTotalReturns())
+                .userStockList(userStocks)
+                .build();
+    }
+
+    private BigDecimal calculateReturns(UserStock us) {
+        // 매입금액 (총 매수 금액)
+        BigDecimal buyAmount = BigDecimal.valueOf(us.getTotalAmount() == null ? 0L : us.getTotalAmount());
+
+        if (buyAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO; // 0으로 나눔 방지
+        }
+
+        // 평가금액 = 현재가 * 수량
+        BigDecimal basePrice = BigDecimal.valueOf(us.getStock().getBasePrice());
+        BigDecimal quantity  = BigDecimal.valueOf(us.getQuantity());
+        BigDecimal valuation = basePrice.multiply(quantity);
+
+        // 손익 = 평가금액 - 매입금액
+        BigDecimal profit = valuation.subtract(buyAmount);
+
+        // 수익률(%) = 손익 / 매입금액 * 100
+        return profit
+                .multiply(BigDecimal.valueOf(100))
+                .divide(buyAmount, 8, RoundingMode.HALF_UP);
+    }
+
 }

--- a/src/main/java/SMU/StockMate/domain/user/dto/PortfolioResponseDTO.java
+++ b/src/main/java/SMU/StockMate/domain/user/dto/PortfolioResponseDTO.java
@@ -3,6 +3,7 @@ package SMU.StockMate.domain.user.dto;
 import SMU.StockMate.domain.userStock.dto.UserStockResponseDTO;
 import lombok.Builder;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Builder
@@ -12,6 +13,6 @@ public record PortfolioResponseDTO(
    Long totalAsset,
    Long cashBalance,
    Long stockValuation,
-   Long totalReturns,
+   BigDecimal totalReturns,
    List<UserStockResponseDTO.toPortfolioDTO> userStockList
 ) {}

--- a/src/main/java/SMU/StockMate/domain/user/entity/User.java
+++ b/src/main/java/SMU/StockMate/domain/user/entity/User.java
@@ -5,6 +5,7 @@ import SMU.StockMate.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +41,10 @@ public class User extends BaseEntity {
     private Long stockValuation = 0L; // 주식 평가 금액
 
     @Builder.Default
-    private Long totalReturns = 0L; // 총 수익률
+    private Long stockTotalBuyAmount = 0L; // 주식 매입 금액
+
+    @Builder.Default
+    private BigDecimal totalReturns = BigDecimal.ZERO; // 총 수익률
 
     private String FcmToken;
 
@@ -51,10 +55,11 @@ public class User extends BaseEntity {
     public void decreaseBalance(Long cost) {
         this.stockValuation += cost;
         this.cashBalance -= cost;
+        this.stockTotalBuyAmount += cost;
     }
 
-    // 주식을 매도한 경우
-    public void increaseBalance(Long cost) {
+    // 주식을 매도한 경우(cost -> 주식 평가 금액, buyCost -> 주식 매입 금액)
+    public void increaseBalance(Long cost, Long buyCost) {
         this.stockValuation -= cost;
         this.cashBalance += cost;
     }

--- a/src/main/java/SMU/StockMate/domain/user/service/PortfolioCommandServiceImpl.java
+++ b/src/main/java/SMU/StockMate/domain/user/service/PortfolioCommandServiceImpl.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Service
@@ -50,12 +52,23 @@ public class PortfolioCommandServiceImpl implements PortfolioCommandService {
                 .build();
     }
 
-    private Long calculateReturns(UserStock userStock) {
-        int currentPrice = userStock.getStock().getBasePrice();
-        Long avgPrice = userStock.getAvgPrice();
-        Long quantity = userStock.getQuantity();
+    private BigDecimal calculateReturns(UserStock us) {
+        long qty  = us.getQuantity() == null ? 0L : us.getQuantity();
+        Integer base = (us.getStock() == null) ? null : us.getStock().getBasePrice();
+        long buy = us.getTotalAmount() == null ? 0L : us.getTotalAmount();
 
-        return (currentPrice - avgPrice) * quantity;
+        // 오류/비정상 데이터 방어: 매입금액, 수량, 현재가가 유효하지 않으면 0%
+        if (buy <= 0L || qty <= 0L || base == null || base <= 0) {
+            return BigDecimal.ZERO.setScale(8);
+        }
+
+        BigDecimal buyAmount = BigDecimal.valueOf(buy);
+        BigDecimal valuation = BigDecimal.valueOf(base).multiply(BigDecimal.valueOf(qty));
+        BigDecimal profit = valuation.subtract(buyAmount);
+
+        // 수익률(%) = 손익 / 매입 * 100
+        return profit.multiply(BigDecimal.valueOf(100))
+                .divide(buyAmount, 8, RoundingMode.HALF_UP);
     }
 }
 

--- a/src/main/java/SMU/StockMate/domain/userStock/dto/UserStockResponseDTO.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/dto/UserStockResponseDTO.java
@@ -2,6 +2,8 @@ package SMU.StockMate.domain.userStock.dto;
 
 import lombok.Builder;
 
+import java.math.BigDecimal;
+
 public class UserStockResponseDTO {
 
     @Builder
@@ -11,7 +13,6 @@ public class UserStockResponseDTO {
             Long totalAmount, // 총 매수 금액
             Long avgPrice, // 평균 매수 금액
             Long quantity, // 보유 수량
-            Long returns // 수익률
-
+            BigDecimal returns // 수익률
     ) {}
 }

--- a/src/main/java/SMU/StockMate/domain/userStock/service/command/v0/UserStockServiceBasic.java
+++ b/src/main/java/SMU/StockMate/domain/userStock/service/command/v0/UserStockServiceBasic.java
@@ -65,7 +65,7 @@ public class UserStockServiceBasic implements UserStockService {
         validateUserStockQuantity(userStock, request.getQuantity());
 
         userStock.reduceStock(request.getQuantity(), totalCost);
-        user.increaseBalance(totalCost);
+        user.increaseBalance(totalCost, request.getQuantity()*userStock.getAvgPrice());
     }
 
     private UserStock createNewUserStock(User user, StockTradingRequest request) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #39 

## 📌 개요
- 1~100명까지의 순위를 보여주기
- 각 순위의 유저를 선택 시 유저의 매수 주식 리스트를 출력

## 🔁 변경 사항
- user 엔티티에 총 수익률 -> Long에서 BigDecimal로 타입 변환
- Long stockTotalBuyAmount : 주식 매입 금액, Long stockValuation : 주식 평가 금액 으로 주식 매입 금액 추가
## 📸 스크린샷
<img width="652" height="240" alt="image" src="https://github.com/user-attachments/assets/97457ffe-76d5-49f1-9f60-7489239b8a2f" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.